### PR TITLE
[PTQ][OV] Sequential models support for Engine without TensorStatistics modifications

### DIFF
--- a/examples/post_training_quantization/onnx/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/main.py
@@ -104,6 +104,7 @@ model = onnx.load(model_path)
 # >> output_names = [output.name for output in sess.get_outputs()]
 # >> for data_item in val_loader:
 # >>    sess.run(output_names, input_feed=transform_fn(data_item))
+
 input_name = model.graph.input[0].name
 
 

--- a/examples/post_training_quantization/openvino/mozilla-deepspeech/accuracy_checker.json
+++ b/examples/post_training_quantization/openvino/mozilla-deepspeech/accuracy_checker.json
@@ -1,0 +1,147 @@
+{
+    "compression": {
+        "algorithms": [
+            {
+                "name": "DefaultQuantization",
+                "params": {
+                    "preset": "performance",
+                    "stat_subset_size": 3
+                }
+            }
+        ],
+        "dump_intermediate_model": true
+    },
+    "engine": {
+        "datasets": [
+            {
+                "metrics": [
+                    {
+                        "type": "wer"
+                    }
+                ],
+                "name": "LibriSpeech_test_clean_wav",
+		"data_source": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/librispeech/test/LibriSpeech/test-clean.wav",
+
+		 "annotation_conversion": {
+      		 	"converter": "librispeech",
+      		 	"data_dir": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/librispeech/test/LibriSpeech/test-clean.wav"
+		 },
+                "preprocessing": [
+                    {
+                        "int16mode": true,
+                        "type": "audio_normalization"
+                    },
+                    {
+                        "duration": "512 samples",
+                        "overlap": "192 samples",
+                        "type": "clip_audio"
+                    },
+                    {
+                        "base": 512,
+                        "type": "hanning_window"
+                    },
+                    {
+                        "fftbase": 512,
+                        "magnitude_squared": true,
+                        "skip_channels": true,
+                        "type": "audio_spectrogram"
+                    },
+                    {
+                        "base": 257,
+                        "filterbank_channel_count": 40,
+                        "lower_frequency_limit": 20,
+                        "sample_rate": 16000,
+                        "type": "audio_triangle_filtering",
+                        "upper_frequency_limit": 4000
+                    },
+                    {
+                        "filterbank_channel_count": 40,
+                        "numceps": 26,
+                        "type": "audio_dct"
+                    },
+                    {
+                        "context": 9,
+                        "numceps": 26,
+                        "type": "clip_cepstrum"
+                    },
+                    {
+                        "step": 16,
+                        "type": "pack_cepstrum"
+                    }
+                ],
+                "reader": "wav_reader"
+            }
+        ],
+        "launchers": [
+            {
+                "adapter": {
+                    "beam_size": 32,
+                    "lm_alpha": 0.75,
+                    "lm_beta": 1.05,
+                    "lm_file": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/model_attributes/mozilla-deepspeech-0.6.1/lm.binary",
+                    "lm_oov_score": -1000,
+                    "lm_vocabulary_length": 4463723,
+                    "lm_vocabulary_offset": 941235601,
+                    "logarithmic_prob": false,
+                    "probability_out": "logits",
+                    "type": "ctc_beam_search_decoder_with_lm"
+                },
+                "framework": "dlsdk",
+                "inputs": [
+                    {
+                        "layout": "NHWC",
+                        "name": "input_node",
+                        "type": "INPUT"
+                    },
+                    {
+                        "name": "previous_state_c",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.2"
+                    },
+                    {
+                        "name": "previous_state_h",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.1"
+                    }
+                ]
+            },
+            {
+                "adapter": {
+                    "beam_size": 32,
+                    "lm_alpha": 0.75,
+                    "lm_beta": 1.05,
+                    "lm_file": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/model_attributes/mozilla-deepspeech-0.6.1/lm.binary",
+                    "lm_oov_score": -1000,
+                    "lm_vocabulary_length": 4463723,
+                    "lm_vocabulary_offset": 941235601,
+                    "logarithmic_prob": false,
+                    "probability_out": "logits",
+                    "type": "ctc_beam_search_decoder_with_lm"
+                },
+                "framework": "openvino",
+                "inputs": [
+                    {
+                        "layout": "NHWC",
+                        "name": "input_node",
+                        "type": "INPUT"
+                    },
+                    {
+                        "name": "previous_state_c",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd:0"
+                    },
+                    {
+                        "name": "previous_state_h",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1:0"
+                    }
+                ]
+            }
+        ]
+    },
+    "model": {
+        "model": "/mnt/omz/cv_bench_cache/ww18_weekly_23.0.0-10862-40bf400b189-API2.0/mozilla-deepspeech-0.6.1/tf/tf_frozen/FP16/1/dldt/mozilla-deepspeech-0.6.1.xml",
+        "model_name": "mozilla-deepspeech-0.6.1",
+        "weights": "/mnt/omz/cv_bench_cache/ww18_weekly_23.0.0-10862-40bf400b189-API2.0/mozilla-deepspeech-0.6.1/tf/tf_frozen/FP16/1/dldt/mozilla-deepspeech-0.6.1.bin"
+    }
+}

--- a/examples/post_training_quantization/openvino/mozilla-deepspeech/main.py
+++ b/examples/post_training_quantization/openvino/mozilla-deepspeech/main.py
@@ -1,0 +1,66 @@
+import subprocess
+import numpy as np
+import os
+import nncf
+import openvino.runtime as ov
+import json
+
+
+from openvino.tools.accuracy_checker.evaluators.quantization_model_evaluator import create_model_evaluator
+from openvino.tools.pot.configs.config import Config
+
+
+model_name = "mozilla-deepspeech-0.6.1"
+cache_dir = os.path.dirname(__file__)
+dataset_config = os.path.join(cache_dir, 'accuracy_checker.json')
+
+command = f"omz_downloader --name {model_name} --cache_dir {cache_dir}"
+cmd_output = subprocess.call(command, shell=True)  # nosec
+
+model_dir = os.path.join(cache_dir, model_name)
+if not os.path.exists(model_dir):
+    command = f"omz_converter --name {model_name} -o {os.path.join(cache_dir, model_name)}"
+    cmd_output = subprocess.call(command, shell=True)  # nosec
+
+xml_path = os.path.join(model_dir, f'public/{model_name}/FP16/{model_name}.xml')
+ov_model = ov.Core().read_model(xml_path)
+
+config = Config.read_config(dataset_config)
+config.configure_params()
+accuracy_checker_config = config.engine
+
+model_evaluator = create_model_evaluator(accuracy_checker_config)
+model_evaluator.load_network([{"model": ov_model}])
+model_evaluator.select_dataset("")
+
+
+def get_tokens_from_sequence_func(data_item):
+    _, batch_annotation, batch_input, _ = data_item
+    filled_inputs, _, _ = model_evaluator._get_batch_input(batch_input, batch_annotation)
+    for filled_input in filled_inputs:
+        input_data = {}
+        for name, value in filled_input.items():
+            input_data[model_evaluator.launcher.input_to_tensor_name[name]] = value
+        yield input_data
+
+
+def fill_sequential_inputs_fn(model_inputs, model_outputs):
+    # Combine model inputs with state model outputs
+    # or fill state model outputs if model_outputs is None
+
+    #state_inputs = {}
+    #for state_input_name, output_name in model_evaluator.launcher._lstm_inputs.items():
+    #    if model_outputs is None:
+    #        input_data = np.zeros(tuple(model_evaluator.launcher.inputs[state_input_name].shape))
+    #    else:
+    #        input_data = model_outputs[output_name]
+    #    state_inputs[state_input_name] = input_data
+
+    state_inputs = model_evaluator.launcher._fill_lstm_inputs(model_outputs)
+    model_inputs.update(state_inputs)
+    return model_inputs
+
+
+dataset = nncf.RecurentDataset(
+    model_evaluator.dataset, get_tokens_from_sequence_func, fill_sequential_inputs_fn)
+quantized_model = nncf.quantize(ov_model, dataset)

--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -15,6 +15,7 @@ from nncf.common.logging.logger import disable_logging
 from nncf.common.logging.logger import set_log_level
 from nncf.config import NNCFConfig
 from nncf.data import Dataset
+from nncf.data import RecurentDataset
 from nncf.parameters import DropType
 from nncf.parameters import ModelType
 from nncf.parameters import TargetDevice

--- a/nncf/data/__init__.py
+++ b/nncf/data/__init__.py
@@ -10,3 +10,5 @@
 # limitations under the License.
 
 from nncf.data.dataset import Dataset
+from nncf.data.dataset import Sequence
+from nncf.data.dataset import RecurentDataset

--- a/nncf/data/__init__.py
+++ b/nncf/data/__init__.py
@@ -10,5 +10,5 @@
 # limitations under the License.
 
 from nncf.data.dataset import Dataset
-from nncf.data.dataset import Sequence
 from nncf.data.dataset import RecurentDataset
+from nncf.data.dataset import Sequence

--- a/nncf/data/dataset.py
+++ b/nncf/data/dataset.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Generic, Iterable, List, Optional, TypeVar
+from typing import Any, Callable, Generic, Iterable, List, Optional, TypeVar
 
 from nncf.common.utils.api_marker import api
 
@@ -115,3 +115,30 @@ class DataProvider(Generic[DataItem, ModelInput]):
             if idx == indices[pos]:
                 pos = pos + 1
                 yield transform_func(data_item)
+
+
+@api(canonical_alias="nncf.RecurentDataset")
+class RecurentDataset(Dataset):
+    def __init__(self, data_source: Iterable, get_token_from_sequence_func, fill_sequential_inputs_fn):
+        def transform_fn_wrapper(data_item):
+            return Sequence(data_item, get_token_from_sequence_func, fill_sequential_inputs_fn)
+
+        super().__init__(data_source, transform_fn_wrapper)
+
+
+class Sequence:
+    def __init__(
+        self,
+        raw_sequence,
+        get_tokens_from_sequence_func: Callable[[DataItem], ModelInput],
+        fill_sequential_inputs_fn: Callable[[DataItem], ModelInput],
+    ):
+        self._raw_sequence = raw_sequence
+        self._get_tokens_from_sequence_func = get_tokens_from_sequence_func
+        self._fill_sequential_inputs_fn = fill_sequential_inputs_fn
+
+    def get_tokens_iter(self):
+        return self._get_tokens_from_sequence_func(self._raw_sequence)
+
+    def fill_inputs(self, token, model_outputs):
+        return self._fill_sequential_inputs_fn(token, model_outputs)

--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -35,8 +35,7 @@ class TensorReducerBase(ABC):
         """
         :param reduction_shape: Reduction shape for reduction calculation. Equal to list(range(len(input.shape)))
             if empty.
-        :param: Wheather should be calculated inplace or out of place.
-
+        :param inplace: Wheather should be calculated inplace or out of place.
         """
         self._reduction_shape = reduction_shape
         self._init_reduction_shape = reduction_shape
@@ -104,6 +103,18 @@ class TensorReducerBase(ABC):
 
     def __hash__(self) -> int:
         return hash((self.__class__.__name__, self.inplace, self._init_reduction_shape))
+
+
+class SequentialTensorReducer:
+    def __init__(self, per_element_reducer: TensorReducerBase, per_sample_reducer: TensorReducerBase):
+        if per_sample_reducer.inplace:
+            raise RuntimeError(f'Per sample reducer could not be inplace.')
+        self._per_element_reducer = per_element_reducer
+        self._per_sample_reducer = per_sample_reducer
+
+    @classmethod
+    def name(self):
+        pass
 
 
 class TensorAggregatorBase:

--- a/nncf/openvino/engine.py
+++ b/nncf/openvino/engine.py
@@ -9,15 +9,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import openvino.runtime as ov
-from collections import defaultdict
 
-from nncf.data import Sequence
 from nncf.common.engine import Engine
+from nncf.data import Sequence
 from nncf.parameters import TargetDevice
+
+SEQUENTIAL_SAMPLE_STACK_AXIS = 0
 
 
 class OVNativeEngine(Engine):
@@ -77,10 +79,9 @@ class OVNativeEngine(Engine):
         # Stack model outputs and return them
         stacked_outputs = {}
         for output_name, output_values in model_outputs.items():
-            stacked_outputs[output_name] = np.stack(output_values, 0)
+            stacked_outputs[output_name] = np.stack(output_values, axis=SEQUENTIAL_SAMPLE_STACK_AXIS)
 
         return stacked_outputs
-
 
     def _infer(
         self, input_data: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray], Dict[str, np.ndarray]]

--- a/nncf/openvino/quantization/quantize_model.py
+++ b/nncf/openvino/quantization/quantize_model.py
@@ -21,6 +21,7 @@ from nncf.common.quantization.structs import QuantizationPreset
 from nncf.common.utils.backend import get_backend
 from nncf.common.utils.timer import timer
 from nncf.data import Dataset
+from nncf.data import RecurentDataset
 from nncf.openvino.quantization.backend_parameters import BackendParameters
 from nncf.openvino.quantization.backend_parameters import is_weight_compression_needed
 from nncf.parameters import DropType
@@ -102,6 +103,9 @@ def native_quantize_impl(
     """
     Implementation of the `quantize()` method for the OpenVINO backend via the OpenVINO Runtime API.
     """
+    if isinstance(calibration_dataset, RecurentDataset):
+        model_type = ModelType.SEQUENTIAL
+
     quantization_algorithm = PostTrainingQuantization(
         preset=preset,
         target_device=target_device,

--- a/nncf/openvino/statistics/collectors.py
+++ b/nncf/openvino/statistics/collectors.py
@@ -40,6 +40,7 @@ from nncf.openvino.graph.node_utils import get_result_node_name
 from nncf.openvino.statistics.statistics import OVBatchTensorStatistic
 from nncf.openvino.statistics.statistics import OVMeanTensorStatistic
 from nncf.openvino.tensor import OVNNCFTensor
+from nncf.parameters import ModelType
 from nncf.quantization.advanced_parameters import StatisticsType
 
 
@@ -242,7 +243,7 @@ class OVAbsQuantileReducer(AbsQuantileReducer):
         return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
-def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace=True):
+def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace=True, model_type=None):
     # TODO(dlyakhov): use inplace OVBatchMeanReducer and OVMeanPerChanelReducer
     # after migration on openvino-dev=2023.0
     inplace = False
@@ -259,7 +260,7 @@ def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace
         "window_size": window_size,
     }
     aggregate_mean = MeanAggregator(**kwargs)
-    aggregate_shape = ShapeAggregator()
+    aggregate_shape = ShapeAggregator(slice(1, None) if model_type == ModelType.SEQUENTIAL else None)
 
     collector = TensorCollector(OVMeanTensorStatistic)
     collector.register_statistic_branch(OVMeanTensorStatistic.MEAN_STAT, reducer, aggregate_mean)

--- a/nncf/parameters.py
+++ b/nncf/parameters.py
@@ -40,6 +40,7 @@ class ModelType(Enum):
     """
 
     TRANSFORMER = "transformer"
+    SEQUENTIAL = "sequential"
 
 
 @api(canonical_alias="nncf.DropType")

--- a/nncf/quantization/algorithms/bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/bias_correction/algorithm.py
@@ -29,6 +29,7 @@ from nncf.common.tensor_statistics.statistic_point import StatisticPointsContain
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import copy_model
 from nncf.common.utils.backend import get_backend
+from nncf.parameters import ModelType
 from nncf.quantization.algorithms.algorithm import Algorithm
 from nncf.quantization.algorithms.bias_correction.backend import ALGO_BACKENDS
 
@@ -68,6 +69,7 @@ class BiasCorrection(Algorithm):
         apply_for_all_nodes: bool = False,
         inplace_statistics: bool = True,
         backend_params: Optional[Dict[str, Any]] = None,
+        model_type: ModelType = None,
     ):
         """
         :param subset_size: Size of a subset for the statistics collection,
@@ -91,6 +93,8 @@ class BiasCorrection(Algorithm):
         self.apply_for_all_nodes = apply_for_all_nodes
         self.inplace_statistics = inplace_statistics
         self.backend_params = backend_params
+        self.model_type = model_type
+
         self.nncf_graph = None
         self._backend_entity = None
         self._collected_stat_inputs = set()
@@ -476,7 +480,10 @@ class BiasCorrection(Algorithm):
                 TargetType.POST_LAYER_OPERATION, node_name, output_port_id
             )
             stat_collector = self._backend_entity.mean_statistic_collector(
-                reduction_shape=channel_axis, num_samples=self.subset_size, inplace=self.inplace_statistics
+                reduction_shape=channel_axis,
+                num_samples=self.subset_size,
+                inplace=self.inplace_statistics,
+                model_type=self.model_type,
             )
             statistic_container.add_statistic_point(
                 StatisticPoint(target_point=statistic_point, tensor_collector=stat_collector, algorithm=BiasCorrection)

--- a/nncf/quantization/algorithms/bias_correction/backend.py
+++ b/nncf/quantization/algorithms/bias_correction/backend.py
@@ -24,6 +24,7 @@ from nncf.common.tensor import NNCFTensor
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
 from nncf.common.utils.registry import Registry
+from nncf.parameters import ModelType
 
 TModel = TypeVar("TModel")
 OutputType = TypeVar("OutputType")
@@ -108,6 +109,7 @@ class BiasCorrectionAlgoBackend(ABC):
         inplace: bool,
         num_samples: Optional[int] = None,
         window_size: Optional[int] = None,
+        model_type: Optional[ModelType] = None,
     ) -> TensorStatisticCollectorBase:
         """
         Returns backend-specific mean statistic collector.

--- a/nncf/quantization/algorithms/bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/onnx_backend.py
@@ -35,6 +35,7 @@ from nncf.onnx.statistics.collectors import ONNXBatchStatisticCollector
 from nncf.onnx.statistics.collectors import ONNXMeanStatisticCollector
 from nncf.onnx.statistics.collectors import ONNXNNCFCollectorTensorProcessor
 from nncf.onnx.tensor import ONNXNNCFTensor
+from nncf.parameters import ModelType
 from nncf.quantization.algorithms.bias_correction.backend import ALGO_BACKENDS
 from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
 
@@ -82,6 +83,7 @@ class ONNXBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: Optional[int] = None,
         window_size: Optional[int] = None,
+        model_type: Optional[ModelType] = None,
     ) -> ONNXMeanStatisticCollector:
         return ONNXMeanStatisticCollector(reduction_shape, num_samples, window_size)
 

--- a/nncf/quantization/algorithms/bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/bias_correction/openvino_backend.py
@@ -34,6 +34,7 @@ from nncf.openvino.statistics.collectors import OVNNCFCollectorTensorProcessor
 from nncf.openvino.statistics.collectors import get_mean_batch_stat_collector
 from nncf.openvino.statistics.collectors import get_mean_stat_collector
 from nncf.openvino.tensor import OVNNCFTensor
+from nncf.parameters import ModelType
 from nncf.quantization.algorithms.bias_correction.backend import ALGO_BACKENDS
 from nncf.quantization.algorithms.bias_correction.backend import BiasCorrectionAlgoBackend
 
@@ -77,8 +78,9 @@ class OVBiasCorrectionAlgoBackend(BiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: Optional[int] = None,
         window_size: Optional[int] = None,
+        model_type: Optional[ModelType] = None,
     ) -> TensorCollector:
-        return get_mean_stat_collector(num_samples, reduction_shape, window_size, inplace)
+        return get_mean_stat_collector(num_samples, reduction_shape, window_size, inplace, model_type)
 
     @staticmethod
     def batch_statistic_collector(inplace: bool, num_samples: int = None) -> TensorCollector:

--- a/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/algorithm.py
@@ -27,6 +27,7 @@ from nncf.common.tensor_statistics.statistic_point import StatisticPoint
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
 from nncf.common.utils.backend import BackendType
 from nncf.common.utils.backend import get_backend
+from nncf.parameters import ModelType
 from nncf.quantization.algorithms.algorithm import Algorithm
 from nncf.quantization.algorithms.fast_bias_correction.backend import ALGO_BACKENDS
 
@@ -59,6 +60,7 @@ class FastBiasCorrection(Algorithm):
         apply_for_all_nodes: bool = False,
         inplace_statistics: bool = True,
         backend_params: Optional[Dict[str, Any]] = None,
+        model_type: ModelType = None,
     ):
         """
         :param subset_size: Size of a subset for the statistics collection,
@@ -82,6 +84,7 @@ class FastBiasCorrection(Algorithm):
         self.apply_for_all_nodes = apply_for_all_nodes
         self.inplace_statistics = inplace_statistics
         self.backend_params = backend_params
+        self.model_type = model_type
         self.nncf_graph = None
         self._backend_entity = None
 
@@ -252,7 +255,10 @@ class FastBiasCorrection(Algorithm):
         :param axis: Channel axis for the statistics calculation.
         """
         stat_collector = self._backend_entity.mean_statistic_collector(
-            reduction_shape=axis, num_samples=self.subset_size, inplace=self.inplace_statistics
+            reduction_shape=axis,
+            num_samples=self.subset_size,
+            inplace=self.inplace_statistics,
+            model_type=self.model_type,
         )
         container.add_statistic_point(
             StatisticPoint(target_point=point, tensor_collector=stat_collector, algorithm=FastBiasCorrection)

--- a/nncf/quantization/algorithms/fast_bias_correction/backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/backend.py
@@ -24,6 +24,7 @@ from nncf.common.tensor import NNCFTensor
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
 from nncf.common.utils.registry import Registry
+from nncf.parameters import ModelType
 
 TModel = TypeVar("TModel")
 OutputType = TypeVar("OutputType")
@@ -87,6 +88,7 @@ class FastBiasCorrectionAlgoBackend(ABC):
         inplace: bool,
         num_samples: Optional[int] = None,
         window_size: Optional[int] = None,
+        model_type: Optional[ModelType] = None,
     ) -> TensorStatisticCollectorBase:
         """
         Returns backend-specific mean statistic collector.

--- a/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/onnx_backend.py
@@ -31,6 +31,7 @@ from nncf.onnx.graph.transformations.commands import ONNXTargetPoint
 from nncf.onnx.statistics.collectors import ONNXMeanStatisticCollector
 from nncf.onnx.statistics.collectors import ONNXNNCFCollectorTensorProcessor
 from nncf.onnx.tensor import ONNXNNCFTensor
+from nncf.parameters import ModelType
 from nncf.quantization.algorithms.fast_bias_correction.backend import ALGO_BACKENDS
 from nncf.quantization.algorithms.fast_bias_correction.backend import FastBiasCorrectionAlgoBackend
 
@@ -65,6 +66,7 @@ class ONNXFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: Optional[int] = None,
         window_size: Optional[int] = None,
+        model_type: Optional[ModelType] = None,
     ) -> ONNXMeanStatisticCollector:
         return ONNXMeanStatisticCollector(reduction_shape, num_samples, window_size)
 

--- a/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
+++ b/nncf/quantization/algorithms/fast_bias_correction/openvino_backend.py
@@ -32,6 +32,7 @@ from nncf.openvino.graph.transformations.commands import OVTargetPoint
 from nncf.openvino.statistics.collectors import OVNNCFCollectorTensorProcessor
 from nncf.openvino.statistics.collectors import get_mean_stat_collector
 from nncf.openvino.tensor import OVNNCFTensor
+from nncf.parameters import ModelType
 from nncf.quantization.algorithms.fast_bias_correction.backend import ALGO_BACKENDS
 from nncf.quantization.algorithms.fast_bias_correction.backend import FastBiasCorrectionAlgoBackend
 
@@ -66,8 +67,9 @@ class OVFastBiasCorrectionAlgoBackend(FastBiasCorrectionAlgoBackend):
         inplace: bool,
         num_samples: Optional[int] = None,
         window_size: Optional[int] = None,
+        model_type: Optional[ModelType] = None,
     ) -> TensorCollector:
-        return get_mean_stat_collector(num_samples, reduction_shape, window_size, inplace)
+        return get_mean_stat_collector(num_samples, reduction_shape, window_size, inplace, model_type)
 
     @staticmethod
     def get_sub_input_output_names(subgraph: ov.Model) -> Tuple[str, str]:

--- a/nncf/quantization/algorithms/min_max/algorithm.py
+++ b/nncf/quantization/algorithms/min_max/algorithm.py
@@ -275,6 +275,7 @@ class MinMaxQuantization(Algorithm):
             target_point,
             quantizer_config,
             inplace=self._inplace_statistics,
+            model_type=self._model_type,
             num_samples=self._subset_size,
         )
 

--- a/nncf/quantization/algorithms/min_max/backend.py
+++ b/nncf/quantization/algorithms/min_max/backend.py
@@ -157,6 +157,7 @@ class MinMaxAlgoBackend(ABC):
         target_point: TargetPoint,
         quantizer_config: QuantizerConfig,
         inplace: bool,
+        model_type: ModelType,
         num_samples: int = None,
     ) -> TensorStatisticCollectorBase:
         """

--- a/nncf/quantization/algorithms/min_max/onnx_backend.py
+++ b/nncf/quantization/algorithms/min_max/onnx_backend.py
@@ -178,6 +178,7 @@ class ONNXMinMaxAlgoBackend(MinMaxAlgoBackend):
         target_point: ONNXTargetPoint,
         quantizer_config: QuantizerConfig,
         inplace: bool,
+        model_type: ModelType,
         num_samples: int = None,
     ) -> Union[ONNXMinMaxStatisticCollector, ONNXMeanMinMaxStatisticCollector]:
         reduction_shape, use_abs_max = ONNXMinMaxAlgoBackend._get_reduction_shape_and_use_abs_max(

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -23,7 +23,9 @@ from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.utils.backend import BackendType
 from nncf.experimental.common.tensor_statistics.collectors import AGGREGATORS_MAP
+from nncf.experimental.common.tensor_statistics.collectors import SequentialTensorReducer
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
+from nncf.openvino.engine import SEQUENTIAL_SAMPLE_STACK_AXIS
 from nncf.openvino.graph.metatypes.openvino_metatypes import GENERAL_WEIGHT_LAYER_METATYPES
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVAddMetatype
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVConvolutionBackpropDataMetatype
@@ -179,6 +181,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
         target_point: OVTargetPoint,
         quantizer_config: QuantizerConfig,
         inplace: bool,
+        model_type: ModelType,
         num_samples: int = None,
     ) -> TensorCollector:
         reduction_shape, use_abs_max = OVMinMaxAlgoBackend._get_reduction_shape_and_use_abs_max(
@@ -212,7 +215,18 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
             statistic_type = params.statistics_type
             if use_abs_max and statistic_type == StatisticsType.MAX:
                 statistic_type = StatisticsType.ABS_MAX
-            reducer = OV_REDUCERS_MAP[statistic_type](**kwargs)
+
+            reducer_cls = OV_REDUCERS_MAP[statistic_type]
+            if model_type == ModelType.SEQUENTIAL:
+                per_element_reducer = reducer_cls(**kwargs)
+                per_sample_reducer_kwargs = kwargs.copy()
+                per_sample_reducer_kwargs.update(
+                    {"reduction_shape": SEQUENTIAL_SAMPLE_STACK_AXIS, "inplace": False, "keepdims": False}
+                )
+                per_sample_reducer = reducer_cls(**per_sample_reducer_kwargs)
+                reducer = SequentialTensorReducer(per_element_reducer, per_sample_reducer)
+            else:
+                reducer = reducer_cls(**kwargs)
 
             kwargs = {"num_samples": _num_samples, "tensor_processor": OVNNCFCollectorTensorProcessor}
             aggregator = AGGREGATORS_MAP[params.aggregator_type](**kwargs)

--- a/nncf/quantization/algorithms/min_max/openvino_backend.py
+++ b/nncf/quantization/algorithms/min_max/openvino_backend.py
@@ -23,8 +23,8 @@ from nncf.common.quantization.structs import QuantizerConfig
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.utils.backend import BackendType
 from nncf.experimental.common.tensor_statistics.collectors import AGGREGATORS_MAP
-from nncf.experimental.common.tensor_statistics.collectors import SequentialTensorReducer
 from nncf.experimental.common.tensor_statistics.collectors import TensorCollector
+from nncf.experimental.common.tensor_statistics.collectors import TensorReducersSequence
 from nncf.openvino.engine import SEQUENTIAL_SAMPLE_STACK_AXIS
 from nncf.openvino.graph.metatypes.openvino_metatypes import GENERAL_WEIGHT_LAYER_METATYPES
 from nncf.openvino.graph.metatypes.openvino_metatypes import OVAddMetatype
@@ -224,7 +224,7 @@ class OVMinMaxAlgoBackend(MinMaxAlgoBackend):
                     {"reduction_shape": SEQUENTIAL_SAMPLE_STACK_AXIS, "inplace": False, "keepdims": False}
                 )
                 per_sample_reducer = reducer_cls(**per_sample_reducer_kwargs)
-                reducer = SequentialTensorReducer(per_element_reducer, per_sample_reducer)
+                reducer = TensorReducersSequence(per_element_reducer, per_sample_reducer)
             else:
                 reducer = reducer_cls(**kwargs)
 

--- a/nncf/quantization/algorithms/min_max/torch_backend.py
+++ b/nncf/quantization/algorithms/min_max/torch_backend.py
@@ -154,6 +154,7 @@ class PTMinMaxAlgoBackend(MinMaxAlgoBackend):
         target_point: PTTargetPoint,
         quantizer_config: QuantizerConfig,
         inplace: bool,
+        model_type: ModelType,
         num_samples: int = None,
     ) -> Union[PTMinMaxStatisticCollector, PTMeanMinMaxStatisticCollector]:
         if (

--- a/nncf/quantization/algorithms/post_training/algorithm.py
+++ b/nncf/quantization/algorithms/post_training/algorithm.py
@@ -114,6 +114,7 @@ class PostTrainingQuantization(Algorithm):
                 apply_for_all_nodes=bias_correction_params.apply_for_all_nodes,
                 inplace_statistics=advanced_parameters.inplace_statistics,
                 backend_params=advanced_parameters.backend_params,
+                model_type=model_type,
             )
         else:
             threshold = BIAS_CORRECTION_THRESHOLD
@@ -126,6 +127,7 @@ class PostTrainingQuantization(Algorithm):
                 apply_for_all_nodes=bias_correction_params.apply_for_all_nodes,
                 inplace_statistics=advanced_parameters.inplace_statistics,
                 backend_params=advanced_parameters.backend_params,
+                model_type=model_type,
             )
 
         self.algorithms.append(bias_correction)

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -107,9 +107,5 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
         pass
 
     @pytest.mark.skip("Merging is not implemented yet")
-    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
-        pass
-
-    @pytest.mark.skip("Merging is not implemented yet")
     def test_statistic_merging(self, dataset_samples, inplace_statistics):
         pass

--- a/tests/onnx/test_statistics_aggregator.py
+++ b/tests/onnx/test_statistics_aggregator.py
@@ -107,5 +107,9 @@ class TestStatisticsAggregator(TemplateTestStatisticsAggregator):
         pass
 
     @pytest.mark.skip("Merging is not implemented yet")
+    def test_same_collectors_different_attrs_dont_merge(self, statistics_type, test_params, dataset_samples):
+        pass
+
+    @pytest.mark.skip("Merging is not implemented yet")
     def test_statistic_merging(self, dataset_samples, inplace_statistics):
         pass


### PR DESCRIPTION
Changes
Sequential dataset with correspondent changes in engine in OV is presented: now user can specify two functions:
** get_tokens_from_sequence_func
** fill_sequential_inputs_fn
to infer sequential a model

TensorReducersSequence is presented

Reason for changes
To allow quantization of sequential models
TensorReducersSequence is needed to reduce statistics of sequential model: first reducer applies for each element in sample, second reducer applies on reduced element of each element
Related tickets
110654

Tests
Not yet
