### PR TITLE
[PTQ][OV] Sequential models support for Engine by TensorCollectorAdapter and by base TensorStatistic 

### DIFF
--- a/examples/post_training_quantization/onnx/mobilenet_v2/main.py
+++ b/examples/post_training_quantization/onnx/mobilenet_v2/main.py
@@ -104,6 +104,7 @@ model = onnx.load(model_path)
 # >> output_names = [output.name for output in sess.get_outputs()]
 # >> for data_item in val_loader:
 # >>    sess.run(output_names, input_feed=transform_fn(data_item))
+
 input_name = model.graph.input[0].name
 
 

--- a/examples/post_training_quantization/openvino/mozilla-deepspeech/accuracy_checker.json
+++ b/examples/post_training_quantization/openvino/mozilla-deepspeech/accuracy_checker.json
@@ -1,0 +1,147 @@
+{
+    "compression": {
+        "algorithms": [
+            {
+                "name": "DefaultQuantization",
+                "params": {
+                    "preset": "performance",
+                    "stat_subset_size": 3
+                }
+            }
+        ],
+        "dump_intermediate_model": true
+    },
+    "engine": {
+        "datasets": [
+            {
+                "metrics": [
+                    {
+                        "type": "wer"
+                    }
+                ],
+                "name": "LibriSpeech_test_clean_wav",
+		"data_source": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/librispeech/test/LibriSpeech/test-clean.wav",
+
+		 "annotation_conversion": {
+      		 	"converter": "librispeech",
+      		 	"data_dir": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/librispeech/test/LibriSpeech/test-clean.wav"
+		 },
+                "preprocessing": [
+                    {
+                        "int16mode": true,
+                        "type": "audio_normalization"
+                    },
+                    {
+                        "duration": "512 samples",
+                        "overlap": "192 samples",
+                        "type": "clip_audio"
+                    },
+                    {
+                        "base": 512,
+                        "type": "hanning_window"
+                    },
+                    {
+                        "fftbase": 512,
+                        "magnitude_squared": true,
+                        "skip_channels": true,
+                        "type": "audio_spectrogram"
+                    },
+                    {
+                        "base": 257,
+                        "filterbank_channel_count": 40,
+                        "lower_frequency_limit": 20,
+                        "sample_rate": 16000,
+                        "type": "audio_triangle_filtering",
+                        "upper_frequency_limit": 4000
+                    },
+                    {
+                        "filterbank_channel_count": 40,
+                        "numceps": 26,
+                        "type": "audio_dct"
+                    },
+                    {
+                        "context": 9,
+                        "numceps": 26,
+                        "type": "clip_cepstrum"
+                    },
+                    {
+                        "step": 16,
+                        "type": "pack_cepstrum"
+                    }
+                ],
+                "reader": "wav_reader"
+            }
+        ],
+        "launchers": [
+            {
+                "adapter": {
+                    "beam_size": 32,
+                    "lm_alpha": 0.75,
+                    "lm_beta": 1.05,
+                    "lm_file": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/model_attributes/mozilla-deepspeech-0.6.1/lm.binary",
+                    "lm_oov_score": -1000,
+                    "lm_vocabulary_length": 4463723,
+                    "lm_vocabulary_offset": 941235601,
+                    "logarithmic_prob": false,
+                    "probability_out": "logits",
+                    "type": "ctc_beam_search_decoder_with_lm"
+                },
+                "framework": "dlsdk",
+                "inputs": [
+                    {
+                        "layout": "NHWC",
+                        "name": "input_node",
+                        "type": "INPUT"
+                    },
+                    {
+                        "name": "previous_state_c",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.2"
+                    },
+                    {
+                        "name": "previous_state_h",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.1"
+                    }
+                ]
+            },
+            {
+                "adapter": {
+                    "beam_size": 32,
+                    "lm_alpha": 0.75,
+                    "lm_beta": 1.05,
+                    "lm_file": "/mnt/omz_new/nn_icv_cv_externalN/omz-validation-datasets/model_attributes/mozilla-deepspeech-0.6.1/lm.binary",
+                    "lm_oov_score": -1000,
+                    "lm_vocabulary_length": 4463723,
+                    "lm_vocabulary_offset": 941235601,
+                    "logarithmic_prob": false,
+                    "probability_out": "logits",
+                    "type": "ctc_beam_search_decoder_with_lm"
+                },
+                "framework": "openvino",
+                "inputs": [
+                    {
+                        "layout": "NHWC",
+                        "name": "input_node",
+                        "type": "INPUT"
+                    },
+                    {
+                        "name": "previous_state_c",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd:0"
+                    },
+                    {
+                        "name": "previous_state_h",
+                        "type": "LSTM_INPUT",
+                        "value": "cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1:0"
+                    }
+                ]
+            }
+        ]
+    },
+    "model": {
+        "model": "/mnt/omz/cv_bench_cache/ww18_weekly_23.0.0-10862-40bf400b189-API2.0/mozilla-deepspeech-0.6.1/tf/tf_frozen/FP16/1/dldt/mozilla-deepspeech-0.6.1.xml",
+        "model_name": "mozilla-deepspeech-0.6.1",
+        "weights": "/mnt/omz/cv_bench_cache/ww18_weekly_23.0.0-10862-40bf400b189-API2.0/mozilla-deepspeech-0.6.1/tf/tf_frozen/FP16/1/dldt/mozilla-deepspeech-0.6.1.bin"
+    }
+}

--- a/examples/post_training_quantization/openvino/mozilla-deepspeech/main.py
+++ b/examples/post_training_quantization/openvino/mozilla-deepspeech/main.py
@@ -1,0 +1,55 @@
+import json
+import os
+import subprocess
+
+import numpy as np
+import openvino.runtime as ov
+from openvino.tools.accuracy_checker.evaluators.quantization_model_evaluator import create_model_evaluator
+from openvino.tools.pot.configs.config import Config
+
+import nncf
+
+model_name = "mozilla-deepspeech-0.6.1"
+cache_dir = os.path.dirname(__file__)
+dataset_config = os.path.join(cache_dir, "accuracy_checker.json")
+
+command = f"omz_downloader --name {model_name} --cache_dir {cache_dir}"
+cmd_output = subprocess.call(command, shell=True)  # nosec
+
+model_dir = os.path.join(cache_dir, model_name)
+if not os.path.exists(model_dir):
+    command = f"omz_converter --name {model_name} -o {os.path.join(cache_dir, model_name)}"
+    cmd_output = subprocess.call(command, shell=True)  # nosec
+
+xml_path = os.path.join(model_dir, f"public/{model_name}/FP16/{model_name}.xml")
+ov_model = ov.Core().read_model(xml_path)
+
+config = Config.read_config(dataset_config)
+config.configure_params()
+accuracy_checker_config = config.engine
+
+model_evaluator = create_model_evaluator(accuracy_checker_config)
+model_evaluator.load_network([{"model": ov_model}])
+model_evaluator.select_dataset("")
+
+
+def get_tokens_from_sequence_func(data_item):
+    _, batch_annotation, batch_input, _ = data_item
+    filled_inputs, _, _ = model_evaluator._get_batch_input(batch_input, batch_annotation)
+    for filled_input in filled_inputs:
+        input_data = {}
+        for name, value in filled_input.items():
+            input_data[model_evaluator.launcher.input_to_tensor_name[name]] = value
+        yield input_data
+
+
+def fill_sequential_inputs_fn(model_inputs, model_outputs):
+    # Combine model inputs with state model outputs
+    # or fill state model outputs if model_outputs is None
+    state_inputs = model_evaluator.launcher._fill_lstm_inputs(model_outputs)
+    model_inputs.update(state_inputs)
+    return model_inputs
+
+
+dataset = nncf.RecurentDataset(model_evaluator.dataset, get_tokens_from_sequence_func, fill_sequential_inputs_fn)
+quantized_model = nncf.quantize(ov_model, dataset, subset_size=3)

--- a/nncf/__init__.py
+++ b/nncf/__init__.py
@@ -15,6 +15,7 @@ from nncf.common.logging.logger import disable_logging
 from nncf.common.logging.logger import set_log_level
 from nncf.config import NNCFConfig
 from nncf.data import Dataset
+from nncf.data import RecurentDataset
 from nncf.parameters import DropType
 from nncf.parameters import ModelType
 from nncf.parameters import TargetDevice

--- a/nncf/common/tensor_statistics/aggregator.py
+++ b/nncf/common/tensor_statistics/aggregator.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 from abc import ABC
 from abc import abstractmethod
+from collections import defaultdict
 from itertools import islice
 from typing import Any, Dict, TypeVar
 
@@ -21,6 +22,7 @@ from nncf.common.graph.transformations.layout import TransformationLayout
 from nncf.common.tensor import NNCFTensor
 from nncf.common.tensor_statistics.statistic_point import StatisticPointsContainer
 from nncf.data.dataset import Dataset
+from nncf.data.dataset import RecurentDataset
 
 TensorType = TypeVar("TensorType")
 TModel = TypeVar("TModel")
@@ -31,10 +33,13 @@ class StatisticsAggregator(ABC):
     Base class for statistics collection.
     """
 
+    STACK_AXIS = 0
+
     def __init__(self, dataset: Dataset):
         self.dataset = dataset
         self.stat_subset_size = None
         self.statistic_points = StatisticPointsContainer()
+        self._is_sequential = isinstance(dataset, RecurentDataset)
 
     def collect_statistics(self, model: TModel) -> None:
         """
@@ -46,18 +51,43 @@ class StatisticsAggregator(ABC):
         model_transformer = ModelTransformerFactory.create(model)
 
         merged_statistics = self._get_merged_statistic_points(self.statistic_points, model)
+        if self._is_sequential:
+            merged_statistics = self._adapt_collectors(merged_statistics, self.STACK_AXIS)
+
         transformation_layout = self._get_transformation_layout_extra_outputs(merged_statistics)
         model_with_outputs = model_transformer.transform(transformation_layout)
         engine = EngineFactory.create(model_with_outputs)
+        infer_fn = self._infer_sequential if self._is_sequential else self._infer
 
         for input_data in tqdm(
             islice(self.dataset.get_inference_data(), self.stat_subset_size),
             total=self.stat_subset_size,
             desc="Statistics collection",
         ):
-            outputs = engine.infer(input_data)
-            processed_outputs = self._process_outputs(outputs)
+            processed_outputs = infer_fn(engine, input_data)
             self._register_statistics(processed_outputs, merged_statistics)
+
+    def _infer(self, engine, input_data):
+        outputs = engine.infer(input_data)
+        return self._process_outputs(outputs)
+
+    def _infer_sequential(self, engine, sequence):
+        model_output = None
+        model_outputs = defaultdict(list)
+        for token in sequence.get_tokens_iter():
+            filled_inputs = sequence.fill_inputs(token, model_output)
+            model_output = engine.infer(filled_inputs)
+            processed_output = self._process_outputs(model_output)
+            for output_name, output_value in processed_output.items():
+                model_outputs[output_name].append(output_value)
+
+        # Stack model outputs and return them
+        stacked_outputs = {}
+        tensor_processor = self._get_tensor_processor()
+        for output_name, output_values in model_outputs.items():
+            stacked_outputs[output_name] = tensor_processor.stack(output_values, axis=self.STACK_AXIS)
+
+        return stacked_outputs
 
     def register_statistic_points(self, statistic_points: StatisticPointsContainer) -> None:
         """
@@ -116,6 +146,10 @@ class StatisticsAggregator(ABC):
         """
 
     @staticmethod
+    def _adapt_collectors(statistic_points: StatisticPointsContainer, stack_axis: int):
+        return statistic_points
+
+    @staticmethod
     @abstractmethod
     def _process_outputs(outputs: Any) -> Dict[str, NNCFTensor]:
         """
@@ -124,3 +158,8 @@ class StatisticsAggregator(ABC):
         :param outputs: raw model outputs
         :return: processed model outputs in Dict[str, NNCFTensor] format
         """
+
+    @staticmethod
+    @abstractmethod
+    def _get_tensor_processor():
+        pass

--- a/nncf/data/__init__.py
+++ b/nncf/data/__init__.py
@@ -10,3 +10,5 @@
 # limitations under the License.
 
 from nncf.data.dataset import Dataset
+from nncf.data.dataset import RecurentDataset
+from nncf.data.dataset import Sequence

--- a/nncf/data/dataset.py
+++ b/nncf/data/dataset.py
@@ -119,9 +119,9 @@ class DataProvider(Generic[DataItem, ModelInput]):
 
 @api(canonical_alias="nncf.RecurentDataset")
 class RecurentDataset(Dataset):
-    def __init__(self, data_source: Iterable, get_token_from_sequence_func, fill_sequential_inputs_fn):
+    def __init__(self, data_source: Iterable, get_token_from_sequence_fn, fill_sequential_inputs_fn):
         def transform_fn_wrapper(data_item):
-            return Sequence(data_item, get_token_from_sequence_func, fill_sequential_inputs_fn)
+            return Sequence(data_item, get_token_from_sequence_fn, fill_sequential_inputs_fn)
 
         super().__init__(data_source, transform_fn_wrapper)
 

--- a/nncf/data/dataset.py
+++ b/nncf/data/dataset.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Generic, Iterable, List, Optional, TypeVar
+from typing import Any, Callable, Generic, Iterable, List, Optional, TypeVar
 
 from nncf.common.utils.api_marker import api
 
@@ -115,3 +115,30 @@ class DataProvider(Generic[DataItem, ModelInput]):
             if idx == indices[pos]:
                 pos = pos + 1
                 yield transform_func(data_item)
+
+
+@api(canonical_alias="nncf.RecurentDataset")
+class RecurentDataset(Dataset):
+    def __init__(self, data_source: Iterable, get_token_from_sequence_func, fill_sequential_inputs_fn):
+        def transform_fn_wrapper(data_item):
+            return Sequence(data_item, get_token_from_sequence_func, fill_sequential_inputs_fn)
+
+        super().__init__(data_source, transform_fn_wrapper)
+
+
+class Sequence:
+    def __init__(
+        self,
+        raw_sequence,
+        get_tokens_from_sequence_func: Callable[[DataItem], ModelInput],
+        fill_sequential_inputs_fn: Callable[[DataItem], ModelInput],
+    ):
+        self._raw_sequence = raw_sequence
+        self._get_tokens_from_sequence_func = get_tokens_from_sequence_func
+        self._fill_sequential_inputs_fn = fill_sequential_inputs_fn
+
+    def get_tokens_iter(self):
+        return self._get_tokens_from_sequence_func(self._raw_sequence)
+
+    def fill_inputs(self, token, model_outputs):
+        return self._fill_sequential_inputs_fn(token, model_outputs)

--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -193,6 +193,8 @@ class TensorStatisticsSequence(TensorStatisticBase):
 
     def __hash__(self) -> int:
         return hash(tuple(hash(statistic) for statistic in self._statistics))
+
+
 class TensorAggregatorBase:
     """
     Tensor aggregator is designed to recieve (register) calculated statistics and

--- a/nncf/experimental/common/tensor_statistics/collectors.py
+++ b/nncf/experimental/common/tensor_statistics/collectors.py
@@ -11,7 +11,6 @@
 
 from abc import ABC
 from abc import abstractmethod
-from abc import abstractproperty
 from abc import abstractstaticmethod
 from collections import defaultdict
 from collections import deque
@@ -21,28 +20,15 @@ from nncf.common.tensor import TensorType
 from nncf.common.tensor_statistics.collectors import NNCFCollectorTensorProcessor
 from nncf.common.tensor_statistics.collectors import NNCFTensor
 from nncf.common.tensor_statistics.collectors import ReductionShape
-from nncf.common.tensor_statistics.statistics import TensorStatistic
 from nncf.quantization.advanced_parameters import AggregatorType
 
 InplaceInsertionFNType = TypeVar("InplaceInsertionFNType")
 
 
-class TensorReducerBase(ABC):
-    """
-    Tensor reducer is a callable object that reduces tensors according to
-    the specified rule. Could handle tensors inplace or out of place.
-    """
-
-    def __init__(self, reduction_shape: Optional[ReductionShape] = None, inplace: bool = False, keepdims: bool = True):
-        """
-        :param reduction_shape: Reduction shape for reduction calculation. Equal to list(range(len(input.shape)))
-            if empty.
-        :param inplace: Wheather should be calculated inplace or out of place.
-        """
-        self._reduction_shape = reduction_shape
-        self._tensor_processor: NNCFCollectorTensorProcessor = self._get_processor()
+class TensorStatisticBase(ABC):
+    def __init__(self, inplace: bool):
         self._inplace = inplace
-        self._keepdims = keepdims
+        self._tensor_processor = self._get_processor()
 
     @property
     def inplace(self):
@@ -80,14 +66,63 @@ class TensorReducerBase(ABC):
         """
 
     @abstractstaticmethod
-    def reduce_out_of_place(x: List[TensorType], **kwargs) -> List[TensorType]:
+    def __call__(self, x: List[NNCFTensor], adapter) -> Any:
+        pass
+
+    def __hash__(self) -> int:
+        return hash((self.__class__.__name__, self.inplace))
+
+    def __eq__(self, __o: object) -> bool:
+        return isinstance(__o, self.__class__) and self._inplace == __o.inplace
+
+
+class TensorReducerBase(TensorStatisticBase, ABC):
+    """
+    Tensor reducer is a callable object that reduces tensors according to
+    the specified rule. Could handle tensors inplace or out of place.
+    """
+
+    def __init__(self, reduction_shape: Optional[ReductionShape] = None, inplace: bool = False, keepdims: bool = True):
+        """
+        :param reduction_shape: Reduction shape for reduction calculation. Equal to list(range(len(input.shape)))
+            if empty.
+        :param inplace: Wheather should be calculated inplace or out of place.
+        """
+        super().__init__(inplace)
+        self._reduction_shape = reduction_shape
+        self._keepdims = keepdims
+
+    @abstractstaticmethod
+    def _reduce_out_of_place(x: List[NNCFTensor], **kwargs) -> List[NNCFTensor]:
         """
         Specifies the reduction rule in terms of NNCFCollectorTensorProcessor.
 
         :param x: Tensor to register.
         """
 
-    def get_kwargs(self):
+    def _reduce_default(self, x: List[NNCFTensor]) -> List[NNCFTensor]:
+        if self.inplace:
+            return x
+        kwargs = self._get_kwargs()
+        kwargs["reduction_shape"] = self._get_reduction_shape(x[0])
+        return self._reduce_out_of_place(x, **kwargs)
+
+    def _reduce_sequential(self, x: List[NNCFTensor], stack_axis: Optional[int] = None) -> List[NNCFTensor]:
+        kwargs = self._get_kwargs()
+        if not self.inplace:
+            kwargs["reduction_shape"] = self._get_reduction_shape(x[0])
+            x = self._reduce_out_of_place(x, **kwargs)
+        kwargs.update({"reduction_shape": stack_axis, "keepdims": False})
+        return self._reduce_out_of_place(x, **kwargs)
+
+    def __call__(self, x: List[NNCFTensor], adapter) -> Any:
+        # TODO: remove isinstance, use something else
+        # like registry
+        if isinstance(adapter, SequentialTensorCollectorAdapter):
+            return self._reduce_sequential(x, adapter.stack_axis)
+        return self._reduce_default(x)
+
+    def _get_kwargs(self):
         return {
             "reduction_shape": self._reduction_shape,
             "tensor_processor": self._tensor_processor,
@@ -111,6 +146,53 @@ class TensorReducerBase(ABC):
         return tuple(range(len(tensor.shape)))
 
 
+class TensorStatisticsSequence(TensorStatisticBase):
+    def __init__(self, *args):
+        if any(statistic.inplace for statistic in args[1:]):
+            raise RuntimeError(f"Only first statistic of sequential tensor statistic could not be inplace.")
+        self._statistics = args
+
+    @property
+    def inplace(self):
+        return self._statistics[0].inplace
+
+    @property
+    def output_port_id(self) -> int:
+        return self._statistics[0].output_port_id
+
+    @property
+    def name(self):
+        name = ""
+        for i, statistic in enumerate(self._statistics):
+            name += f"{i}_{statistic.name}"
+        return name
+
+    def get_output_names(self, target_node_name: str, port_id: int) -> List[str]:
+        return self._statistics[0].get_output_names(target_node_name, port_id)
+
+    def get_inplace_fn(self) -> Optional[InplaceInsertionFNType]:
+        return self._statistics[0].get_inplace_fn()
+
+    def __call__(self, x: List[NNCFTensor], adapter):
+        # Ignore feeded adapter
+        # Could be configurable
+        adapter = DefaultTensorCollectorAdapter()
+        if not self._statistics[0].inplace:
+            x = self._statistics[0](x, adapter)
+
+        for statistic in self._statistics[1:]:
+            x = statistic(x, adapter)
+        return x
+
+    def __eq__(self, __o: object) -> bool:
+        return (
+            isinstance(__o, self.__class__)
+            and len(self._statistics) == len(__o._statistics)
+            and all(self_r == o_r for self_r, o_r in zip(self._statistics, __o._statistics))
+        )
+
+    def __hash__(self) -> int:
+        return hash(tuple(hash(statistic) for statistic in self._statistics))
 class TensorAggregatorBase:
     """
     Tensor aggregator is designed to recieve (register) calculated statistics and
@@ -134,14 +216,14 @@ class TensorAggregatorBase:
     def num_samples(self) -> int:
         return self._num_samples
 
-    def register_reduced_input(self, x: TensorType):
+    def register_reduced_input(self, x: NNCFTensor, adapter):
         if self._num_samples is not None and self._collected_samples >= self._num_samples:
             return
-        self._register_reduced_input_impl(x)
+        self._register_reduced_input_impl(x, adapter)
         self._collected_samples += 1
 
     @abstractmethod
-    def _register_reduced_input_impl(self, x: TensorType) -> None:
+    def _register_reduced_input_impl(self, x: TensorType, adapter) -> None:
         """
         Registers incoming tensor in tensor aggregator.
 
@@ -167,52 +249,18 @@ class TensorAggregatorBase:
         return hash(self.__class__.__name__)
 
 
-class BaseTensorCollectorAdapter(ABC):
-    @abstractmethod
-    def reduce(self, x: List[NNCFTensor], reducer: TensorReducerBase):
-        pass
-
-    @abstractmethod
-    def register_reduced_input(self, x: NNCFTensor, aggregator: TensorAggregatorBase):
-        pass
+class BaseTensorCollectorAdapter:
+    pass
 
 
 class DefaultTensorCollectorAdapter(BaseTensorCollectorAdapter):
-    def reduce(self, x: List[NNCFTensor], reducer: TensorReducerBase):
-        if reducer.inplace:
-            return x
-
-        kwargs = reducer.get_kwargs()
-        reduction_shape_key = "reduction_shape"
-        if reduction_shape_key in kwargs and kwargs[reduction_shape_key] is None:
-            kwargs[reduction_shape_key] = tuple(range(len(x[0].shape)))
-
-        return reducer.reduce_out_of_place(x, **kwargs)
-
-    def register_reduced_input(self, x: NNCFTensor, aggregator: TensorAggregatorBase):
-        aggregator.register_reduced_input(x)
+    pass
 
 
 class SequentialTensorCollectorAdapter(DefaultTensorCollectorAdapter):
-    def __init__(self, stack_axis: int, tensor_processor: NNCFCollectorTensorProcessor) -> None:
+    def __init__(self, stack_axis: int) -> None:
         super().__init__()
-        self._stack_axis = stack_axis
-        self._tensor_processor = tensor_processor
-
-    def reduce(self, x: List[NNCFTensor], reducer: TensorReducerBase):
-        per_element_result = super().reduce(x, reducer)
-        kwargs = reducer.get_kwargs()
-        new_params = {"reduction_shape": self._stack_axis, "keepdims": False}
-        if not all(k in kwargs for k in new_params):
-            return per_element_result
-
-        kwargs.update(new_params)
-        return reducer.reduce_out_of_place(per_element_result, **kwargs)
-
-    def register_reduced_input(self, x: NNCFTensor, aggregator: TensorAggregatorBase):
-        if isinstance(aggregator, ShapeAggregator):
-            x = self._tensor_processor.unstack(x, axis=0)[0]
-        super().register_reduced_input(x, aggregator)
+        self.stack_axis = stack_axis
 
 
 class TensorCollector:
@@ -225,7 +273,7 @@ class TensorCollector:
     a dict could be collected by `get_statistics` call.
     """
 
-    def __init__(self, statistic_container: Optional[TensorStatistic] = None) -> None:
+    def __init__(self, statistic_container: Optional[TensorStatisticBase] = None) -> None:
         self._reducers: Set[TensorReducerBase] = set()
         self._aggregators: Dict[Tuple[int, int], TensorAggregatorBase] = {}
         self._stat_container_kwargs_map: Dict[str, Tuple[int, int]] = {}
@@ -325,14 +373,14 @@ class TensorCollector:
             input_ = inputs[reducer_hash]
             if any([tensor.is_empty() for tensor in input_]):
                 continue
-            reduced_inputs[reducer_hash] = self._adapter.reduce(input_, reducer)
+            reduced_inputs[reducer_hash] = reducer(input_, self._adapter)
 
         for (
             (reducer_hash, reducer_port_id, _),
             aggregator,
         ) in self._aggregators.items():
             if reducer_hash in reduced_inputs:
-                self._adapter.register_reduced_input(reduced_inputs[reducer_hash][reducer_port_id], aggregator)
+                aggregator.register_reduced_input(reduced_inputs[reducer_hash][reducer_port_id], self._adapter)
 
     def _aggregate(self) -> None:
         result = {}
@@ -344,7 +392,7 @@ class TensorCollector:
             result[key] = val
         return result
 
-    def get_statistics(self) -> Union[TensorStatistic, Dict[str, Any]]:
+    def get_statistics(self) -> Union[TensorStatisticBase, Dict[str, Any]]:
         """
         Returns aggregated values in format of a TensorStatistic instance or
         a dict.
@@ -450,12 +498,9 @@ class MergedTensorCollector(TensorCollector):
 ##################################################Reducers##################################################
 
 
-class NoopReducer(TensorReducerBase):
+class NoopStatistic(TensorStatisticBase):
     def __init__(self):
         super().__init__(inplace=False)
-
-    def get_kwargs(self):
-        return {}
 
     @staticmethod
     def _get_processor() -> NNCFCollectorTensorProcessor:
@@ -464,14 +509,13 @@ class NoopReducer(TensorReducerBase):
     def get_inplace_fn(self) -> Optional[InplaceInsertionFNType]:
         return None
 
-    @staticmethod
-    def reduce_out_of_place(x: List[TensorType]) -> List[TensorType]:
+    def __call__(self, x: List[NNCFTensor], adapter) -> Any:
         return x
 
 
 class MinReducer(TensorReducerBase):
     @staticmethod
-    def reduce_out_of_place(
+    def _reduce_out_of_place(
         x: List[NNCFTensor],
         tensor_processor: NNCFCollectorTensorProcessor,
         reduction_shape: Tuple[int, ...],
@@ -482,7 +526,7 @@ class MinReducer(TensorReducerBase):
 
 class MaxReducer(TensorReducerBase):
     @staticmethod
-    def reduce_out_of_place(
+    def _reduce_out_of_place(
         x: List[NNCFTensor],
         tensor_processor: NNCFCollectorTensorProcessor,
         reduction_shape: Tuple[int, ...],
@@ -493,7 +537,7 @@ class MaxReducer(TensorReducerBase):
 
 class AbsMaxReducer(TensorReducerBase):
     @staticmethod
-    def reduce_out_of_place(
+    def _reduce_out_of_place(
         x: List[NNCFTensor],
         tensor_processor: NNCFCollectorTensorProcessor,
         reduction_shape: Tuple[int, ...],
@@ -505,7 +549,7 @@ class AbsMaxReducer(TensorReducerBase):
 
 class MeanReducer(TensorReducerBase):
     @staticmethod
-    def reduce_out_of_place(
+    def _reduce_out_of_place(
         x: List[NNCFTensor],
         tensor_processor: NNCFCollectorTensorProcessor,
         reduction_shape: Tuple[int, ...],
@@ -525,8 +569,8 @@ class QuantileReducerBase(TensorReducerBase):
         super().__init__(reduction_shape, False, keepdims)
         self._quantile = quantile
 
-    def get_kwargs(self):
-        kwargs = super().get_kwargs()
+    def _get_kwargs(self):
+        kwargs = super()._get_kwargs()
         kwargs["quantile"] = self._quantile
         return kwargs
 
@@ -547,7 +591,7 @@ class QuantileReducerBase(TensorReducerBase):
 
 class QuantileReducer(QuantileReducerBase):
     @staticmethod
-    def reduce_out_of_place(
+    def _reduce_out_of_place(
         x: List[NNCFTensor],
         tensor_processor: NNCFCollectorTensorProcessor,
         reduction_shape: Tuple[int, ...],
@@ -567,7 +611,7 @@ class AbsQuantileReducer(QuantileReducerBase):
         super().__init__(reduction_shape, quantile, False)
 
     @staticmethod
-    def reduce_out_of_place(
+    def _reduce_out_of_place(
         x: List[NNCFTensor],
         tensor_processor: NNCFCollectorTensorProcessor,
         reduction_shape: Tuple[int, ...],
@@ -578,35 +622,27 @@ class AbsQuantileReducer(QuantileReducerBase):
         return tensor_processor.quantile(x, [quantile], reduction_shape, keepdims=keepdims)
 
 
-class BatchMeanReducer(TensorReducerBase):
+class BatchMeanStatistic(TensorStatisticBase):
     def __init__(self, inplace: bool = False):
-        super().__init__(None, inplace)
+        super().__init__(inplace)
 
-    def get_kwargs(self):
-        return {
-            "tensor_processor": self._tensor_processor,
-        }
-
-    @staticmethod
-    def reduce_out_of_place(x: List[NNCFTensor], tensor_processor: NNCFCollectorTensorProcessor) -> List[NNCFTensor]:
-        return [tensor_processor.batch_mean(x[0])]
+    def __call__(self, x: List[NNCFTensor], adapter) -> List[NNCFTensor]:
+        return [self._tensor_processor.batch_mean(x[0])]
 
 
-class MeanPerChReducer(TensorReducerBase):
+class MeanPerChReducer(TensorStatisticBase):
     def __init__(self, channel_dim: int = 1, inplace: bool = False):
-        super().__init__(channel_dim, inplace)
+        super().__init__(inplace)
+        self._channel_dim = channel_dim
 
-    def get_kwargs(self):
-        return {
-            "tensor_processor": self._tensor_processor,
-            "channel_dim": self._reduction_shape,
-        }
+    def __call__(self, x: List[NNCFTensor], adapter) -> List[NNCFTensor]:
+        return [self._tensor_processor.mean_per_channel(x[0], self._channel_dim)]
 
-    @staticmethod
-    def reduce_out_of_place(
-        x: List[NNCFTensor], tensor_processor: NNCFCollectorTensorProcessor, channel_dim: int
-    ) -> List[NNCFTensor]:
-        return [tensor_processor.mean_per_channel(x[0], channel_dim)]
+    def __hash__(self) -> int:
+        return hash((self.__class__.__name__, self._inplace, self._channel_dim))
+
+    def __eq__(self, __o: object) -> bool:
+        return super().__eq__(__o) and self._channel_dim == __o._channel_dim
 
 
 ##################################################Aggregators##################################################
@@ -616,7 +652,7 @@ class NoopAggregator(TensorAggregatorBase):
     def __init__(self, num_samples: Optional[int]):
         super().__init__(None, num_samples)
 
-    def _register_reduced_input_impl(self, x: TensorType) -> None:
+    def _register_reduced_input_impl(self, x: TensorType, adapter) -> None:
         self._container.append(x.tensor)
 
     def aggregate(self):
@@ -624,18 +660,23 @@ class NoopAggregator(TensorAggregatorBase):
 
 
 class ShapeAggregator(TensorAggregatorBase):
-    def __init__(self):
-        super().__init__(None, 1)
+    def __init__(self, tensor_processor: NNCFCollectorTensorProcessor):
+        super().__init__(tensor_processor, 1)
 
-    def _register_reduced_input_impl(self, x: TensorType) -> None:
-        self._container = x
+    def _register_reduced_input_impl(self, x: TensorType, adapter) -> None:
+        if isinstance(adapter, SequentialTensorCollectorAdapter):
+            self._container = self._tensor_processor.unstack(x)[0]
+        elif isinstance(adapter, DefaultTensorCollectorAdapter):
+            self._container = x
+        else:
+            raise RuntimeError()
 
     def aggregate(self):
         return self._container.shape
 
 
 class MinAggregator(TensorAggregatorBase):
-    def _register_reduced_input_impl(self, x: TensorType) -> None:
+    def _register_reduced_input_impl(self, x: TensorType, adapter) -> None:
         if not self._container:
             self._container = x
         else:
@@ -646,7 +687,7 @@ class MinAggregator(TensorAggregatorBase):
 
 
 class MaxAggregator(TensorAggregatorBase):
-    def _register_reduced_input_impl(self, x: TensorType) -> None:
+    def _register_reduced_input_impl(self, x: TensorType, adapter) -> None:
         if not self._container:
             self._container = x
         else:
@@ -665,7 +706,7 @@ class OfflineAggregatorBase(TensorAggregatorBase):
         self._container = deque(maxlen=window_size)
         self._use_per_sample_stats = use_per_sample_stats
 
-    def _register_reduced_input_impl(self, x: TensorType) -> None:
+    def _register_reduced_input_impl(self, x: TensorType, adapter) -> None:
         if self._use_per_sample_stats:
             self._container.extend(self._tensor_processor.unstack(x))
         else:

--- a/nncf/onnx/statistics/aggregator.py
+++ b/nncf/onnx/statistics/aggregator.py
@@ -79,3 +79,8 @@ class ONNXStatisticsAggregator(StatisticsAggregator):
     @staticmethod
     def _process_outputs(outputs: Dict[str, np.ndarray]) -> Dict[str, ONNXNNCFTensor]:
         return {n: ONNXNNCFTensor(v) for n, v in outputs.items()}
+
+    def _get_tensor_processor():
+        from nncf.onnx.statistics.collectors import ONNXNNCFCollectorTensorProcessor
+
+        return ONNXNNCFCollectorTensorProcessor

--- a/nncf/openvino/statistics/aggregator.py
+++ b/nncf/openvino/statistics/aggregator.py
@@ -78,7 +78,7 @@ class OVStatisticsAggregator(StatisticsAggregator):
     # TODO(dlyakhov) Move this to common part
     def _adapt_collectors(statistic_points: StatisticPointsContainer, stack_axis: int):
         for _, _, tensor_collector in statistic_points.get_tensor_collectors():
-            tensor_collector.set_adapter(SequentialTensorCollectorAdapter(stack_axis, OVNNCFCollectorTensorProcessor))
+            tensor_collector.set_adapter(SequentialTensorCollectorAdapter(stack_axis))
 
         return statistic_points
 

--- a/nncf/openvino/statistics/collectors.py
+++ b/nncf/openvino/statistics/collectors.py
@@ -18,7 +18,7 @@ from nncf.common.tensor import TensorElementsType
 from nncf.common.tensor_statistics.collectors import NNCFCollectorTensorProcessor
 from nncf.experimental.common.tensor_statistics.collectors import AbsMaxReducer
 from nncf.experimental.common.tensor_statistics.collectors import AbsQuantileReducer
-from nncf.experimental.common.tensor_statistics.collectors import BatchMeanReducer
+from nncf.experimental.common.tensor_statistics.collectors import BatchMeanStatistic
 from nncf.experimental.common.tensor_statistics.collectors import InplaceInsertionFNType
 from nncf.experimental.common.tensor_statistics.collectors import MaxReducer
 from nncf.experimental.common.tensor_statistics.collectors import MeanAggregator
@@ -196,7 +196,7 @@ class OVMeanReducer(MeanReducer):
         return get_reducer_output_node_names(self.name, target_node_name, port_id, self.output_port_id, self.inplace)
 
 
-class OVBatchMeanReducer(BatchMeanReducer):
+class OVBatchMeanReducer(BatchMeanStatistic):
     def _get_processor(self):
         return OVNNCFCollectorTensorProcessor
 
@@ -257,7 +257,7 @@ def get_mean_stat_collector(num_samples, channel_axis, window_size=None, inplace
         "window_size": window_size,
     }
     aggregate_mean = MeanAggregator(**kwargs)
-    aggregate_shape = ShapeAggregator()
+    aggregate_shape = ShapeAggregator(tensor_processor=OVNNCFCollectorTensorProcessor)
 
     collector = TensorCollector(OVMeanTensorStatistic)
     collector.register_statistic_branch(OVMeanTensorStatistic.MEAN_STAT, reducer, aggregate_mean)

--- a/nncf/tensorflow/tensor_statistics/statistics.py
+++ b/nncf/tensorflow/tensor_statistics/statistics.py
@@ -14,7 +14,7 @@ import tensorflow as tf
 from nncf.common.tensor_statistics.statistics import MedianMADTensorStatistic
 from nncf.common.tensor_statistics.statistics import MinMaxTensorStatistic
 from nncf.common.tensor_statistics.statistics import PercentileTensorStatistic
-from nncf.common.tensor_statistics.statistics import TensorStatistic
+from nncf.common.tensor_statistics.statistics import TensorStatisticBase
 
 
 class TFMinMaxTensorStatistic(MinMaxTensorStatistic):
@@ -35,7 +35,7 @@ class TFPercentileTensorStatistic(PercentileTensorStatistic):
         return bool(tf.experimental.numpy.allclose(tensor1, tensor2, rtol=rtol))
 
 
-def tf_convert_stat_to_min_max_tensor_stat(statistic: TensorStatistic) -> TFMinMaxTensorStatistic:
+def tf_convert_stat_to_min_max_tensor_stat(statistic: TensorStatisticBase) -> TFMinMaxTensorStatistic:
     if isinstance(statistic, TFMinMaxTensorStatistic):
         return statistic
     if isinstance(statistic, TFMedianMADTensorStatistic):

--- a/nncf/torch/quantization/algo.py
+++ b/nncf/torch/quantization/algo.py
@@ -141,7 +141,7 @@ from nncf.torch.structures import QuantizationPrecisionInitArgs
 from nncf.torch.tensor_statistics.algo import TensorStatisticsCollectionBuilder
 from nncf.torch.tensor_statistics.collectors import ReductionShape
 from nncf.torch.tensor_statistics.statistics import MinMaxTensorStatistic
-from nncf.torch.tensor_statistics.statistics import TensorStatistic
+from nncf.torch.tensor_statistics.statistics import TensorStatisticBase
 from nncf.torch.tensor_statistics.statistics import pt_convert_stat_to_min_max_tensor_stat
 from nncf.torch.utils import get_model_device
 from nncf.torch.utils import get_model_dtype
@@ -583,7 +583,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
     def _get_minmax_values_for_quantizer_locations(
         self,
         quantizer_setup: SingleConfigQuantizerSetup,
-        tensor_statistics: Dict[PTTargetPoint, Dict[ReductionShape, TensorStatistic]],
+        tensor_statistics: Dict[PTTargetPoint, Dict[ReductionShape, TensorStatisticBase]],
         target_model_graph: PTNNCFGraph,
     ) -> Dict[QuantizationPointId, MinMaxTensorStatistic]:
         retval = {}
@@ -663,7 +663,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
     @staticmethod
     def get_statistics_for_quantizer_setup(
         target_model: NNCFNetwork, quantizer_setup: QuantizerSetupBase, range_init_params: PTRangeInitParams
-    ) -> Dict[PTTargetPoint, Dict[ReductionShape, TensorStatistic]]:
+    ) -> Dict[PTTargetPoint, Dict[ReductionShape, TensorStatisticBase]]:
         if range_init_params is None:
             return {}
         observation_points_vs_collectors_dict = (
@@ -687,7 +687,7 @@ class QuantizationBuilder(PTCompressionAlgorithmBuilder):
 
     def _get_statistics_for_final_range_init(
         self, target_model: NNCFNetwork, quantizer_setup: QuantizerSetupBase, range_init_params: PTRangeInitParams
-    ) -> Dict[PTTargetPoint, Dict[ReductionShape, TensorStatistic]]:
+    ) -> Dict[PTTargetPoint, Dict[ReductionShape, TensorStatisticBase]]:
         return self.get_statistics_for_quantizer_setup(target_model, quantizer_setup, range_init_params)
 
     def _get_single_config_quantizer_setup(self, target_model) -> SingleConfigQuantizerSetup:
@@ -1670,7 +1670,7 @@ class ExperimentalQuantizationBuilder(QuantizationBuilder):
         self,
         quantizer_setup: MultiConfigQuantizerSetup,
         initial_quantizer_setup: SingleConfigQuantizerSetup,
-        tensor_stats_for_all_setup_variations: Dict[PTTargetPoint, Dict[ReductionShape, TensorStatistic]],
+        tensor_stats_for_all_setup_variations: Dict[PTTargetPoint, Dict[ReductionShape, TensorStatisticBase]],
         hw_config: HWConfig = None,
     ):
         should_init = bool(tensor_stats_for_all_setup_variations)
@@ -1689,7 +1689,7 @@ class ExperimentalQuantizationBuilder(QuantizationBuilder):
 
     def _get_statistics_for_final_range_init(
         self, target_model: NNCFNetwork, quantizer_setup: QuantizerSetupBase, range_init_params: PTRangeInitParams
-    ) -> Dict[PTTargetPoint, Dict[ReductionShape, TensorStatistic]]:
+    ) -> Dict[PTTargetPoint, Dict[ReductionShape, TensorStatisticBase]]:
         return self._tensor_stats
 
     def _build_controller(self, model: NNCFNetwork) -> "ExperimentalQuantizationController":
@@ -1745,7 +1745,7 @@ class ExperimentalQuantizationController(QuantizationController):
         quantizer_setup: MultiConfigQuantizerSetup,
         initial_quantizer_setup: SingleConfigQuantizerSetup,
         setup_to_module_id_translation_dict: Dict[QuantizationPointId, QuantizerId],
-        tensor_stats: Dict[PTTargetPoint, Dict[ReductionShape, TensorStatistic]],
+        tensor_stats: Dict[PTTargetPoint, Dict[ReductionShape, TensorStatisticBase]],
         build_time_metric_info: QuantizationShareBuildTimeInfo,
         should_setup_adjust_pad_ops=False,
         hw_config: HWConfig = None,

--- a/nncf/torch/statistics/aggregator.py
+++ b/nncf/torch/statistics/aggregator.py
@@ -67,3 +67,8 @@ class PTStatisticsAggregator(StatisticsAggregator):
     @staticmethod
     def _process_outputs(outputs: Dict[str, np.ndarray]) -> Dict[str, PTNNCFTensor]:
         return outputs
+
+    def _get_tensor_processor():
+        from nncf.torch.tensor_statistics.collectors import PTNNCFCollectorTensorProcessor
+
+        return PTNNCFCollectorTensorProcessor

--- a/nncf/torch/tensor_statistics/statistics.py
+++ b/nncf/torch/tensor_statistics/statistics.py
@@ -14,7 +14,7 @@ import torch
 from nncf.common.tensor_statistics.statistics import MedianMADTensorStatistic
 from nncf.common.tensor_statistics.statistics import MinMaxTensorStatistic
 from nncf.common.tensor_statistics.statistics import PercentileTensorStatistic
-from nncf.common.tensor_statistics.statistics import TensorStatistic
+from nncf.common.tensor_statistics.statistics import TensorStatisticBase
 
 
 class PTMinMaxTensorStatistic(MinMaxTensorStatistic):
@@ -35,7 +35,7 @@ class PTPercentileTensorStatistic(PercentileTensorStatistic):
         return bool(torch.allclose(tensor1, tensor2, rtol=rtol))
 
 
-def pt_convert_stat_to_min_max_tensor_stat(statistic: TensorStatistic) -> PTMinMaxTensorStatistic:
+def pt_convert_stat_to_min_max_tensor_stat(statistic: TensorStatisticBase) -> PTMinMaxTensorStatistic:
     if isinstance(statistic, PTMinMaxTensorStatistic):
         return statistic
     if isinstance(statistic, PTMedianMADTensorStatistic):

--- a/tests/tensorflow/tensor_statistics/test_tensor_statistics.py
+++ b/tests/tensorflow/tensor_statistics/test_tensor_statistics.py
@@ -19,7 +19,7 @@ from nncf.common.tensor_statistics.collectors import OfflineTensorStatisticColle
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.tensor_statistics.collectors import StatisticsNotCollectedError
 from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
-from nncf.common.tensor_statistics.statistics import TensorStatistic
+from nncf.common.tensor_statistics.statistics import TensorStatisticBase
 from nncf.tensorflow.tensor import TFNNCFTensor
 from nncf.tensorflow.tensor_statistics.collectors import TFMeanMinMaxStatisticCollector
 from nncf.tensorflow.tensor_statistics.collectors import TFMeanPercentileStatisticCollector
@@ -101,7 +101,7 @@ class TestCollectedStatistics:
     def test_collected_statistics_with_shape_convert(
         self,
         collector: Type[TensorStatisticCollectorBase],
-        reduction_shapes_vs_ref_statistic: Dict[Tuple[ReductionShape, ReductionShape], TensorStatistic],
+        reduction_shapes_vs_ref_statistic: Dict[Tuple[ReductionShape, ReductionShape], TensorStatisticBase],
     ):
         for reduction_shape in reduction_shapes_vs_ref_statistic.keys():
             collector_obj = collector(use_abs_max=True, reduction_shape=reduction_shape)
@@ -179,7 +179,7 @@ class TestCollectedStatistics:
     def test_collected_statistics(
         self,
         collector: Type[TensorStatisticCollectorBase],
-        reduction_shapes_vs_ref_statistic: Dict[ReductionShape, TensorStatistic],
+        reduction_shapes_vs_ref_statistic: Dict[ReductionShape, TensorStatisticBase],
     ):
         for reduction_shape in reduction_shapes_vs_ref_statistic.keys():
             collector_obj = collector(reduction_shape=reduction_shape)

--- a/tests/torch/tensor_statistics/test_tensor_statistics.py
+++ b/tests/torch/tensor_statistics/test_tensor_statistics.py
@@ -19,7 +19,7 @@ from nncf.common.tensor_statistics.collectors import OfflineTensorStatisticColle
 from nncf.common.tensor_statistics.collectors import ReductionShape
 from nncf.common.tensor_statistics.collectors import StatisticsNotCollectedError
 from nncf.common.tensor_statistics.collectors import TensorStatisticCollectorBase
-from nncf.common.tensor_statistics.statistics import TensorStatistic
+from nncf.common.tensor_statistics.statistics import TensorStatisticBase
 from nncf.torch.tensor import PTNNCFTensor
 from nncf.torch.tensor_statistics.collectors import PTMeanMinMaxStatisticCollector
 from nncf.torch.tensor_statistics.collectors import PTMeanPercentileStatisticCollector
@@ -109,7 +109,7 @@ class TestCollectedStatistics:
     def test_collected_statistics_with_shape_convert(
         self,
         collector: Type[TensorStatisticCollectorBase],
-        reduction_shapes_vs_ref_statistic: Dict[Tuple[ReductionShape, ReductionShape], TensorStatistic],
+        reduction_shapes_vs_ref_statistic: Dict[Tuple[ReductionShape, ReductionShape], TensorStatisticBase],
     ):
         for shapes in reduction_shapes_vs_ref_statistic.keys():
             output_shape, reduction_shape = shapes
@@ -189,7 +189,7 @@ class TestCollectedStatistics:
     def test_collected_statistics(
         self,
         collector: Type[TensorStatisticCollectorBase],
-        reduction_shapes_vs_ref_statistic: Dict[ReductionShape, TensorStatistic],
+        reduction_shapes_vs_ref_statistic: Dict[ReductionShape, TensorStatisticBase],
     ):
         for shapes in reduction_shapes_vs_ref_statistic.keys():
             reduction_shape = shapes


### PR DESCRIPTION
### Changes

* TensorReducer separated now is a subclass of TensorStatistic
* Reducers and Aggregators receive an adapter with input tensor: with an adapter reducer/aggregator can choose right behavior 